### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/mpalmowski/c9c53e50-a425-4405-9d1a-d735ed0fb8e1/5f7b72aa-dbed-415b-820f-4d5db5ad1e47/_apis/work/boardbadge/68d3302a-4e9f-4fd1-9151-1f16fdf6385a)](https://dev.azure.com/mpalmowski/c9c53e50-a425-4405-9d1a-d735ed0fb8e1/_boards/board/t/5f7b72aa-dbed-415b-820f-4d5db5ad1e47/Microsoft.RequirementCategory)
 <p align="center">
   <img src="timber-wp-acf-blocks.png">
 </p>


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/mpalmowski/c9c53e50-a425-4405-9d1a-d735ed0fb8e1/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.