### PR TITLE
Corrected PostTypes Parameter docs

### DIFF
--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -6,7 +6,7 @@
  Category:
  Icon:
  Keywords: (comma-separated)
- PostTypes: 	(comma-separated)
+ PostTypes: (space-separated)
  Mode:
  Align:
  EnqueueStyle:


### PR DESCRIPTION
This parameter is expecting a space separated list of post types.