### PR TITLE
Deprecated: Using ${var} in strings is deprecated, use {$var} instead in

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,16 @@
 {
-  "name": "palmiak/timber-acf-wp-blocks",
+  "name": "bartnovak/timber-acf-wp-blocks",
   "description": "Create Gutenberg blocks from Twig templates and ACF fields.",
   "keywords": ["wordpress", "gutenberg", "advanced custom fields"],
   "require": {
       "php": ">=5.6"
   },
   "license": "MIT",
-  "authors": [
+    "authors": [
+      {
+        "name": "OsomStudio",
+        "email": "b.nowak@osomstudio.com"
+      },
       {
           "name": "Maciej Palmowski",
           "email": "m.palmowski@freshpixels.pl"

--- a/timber-acf-wp-blocks.php
+++ b/timber-acf-wp-blocks.php
@@ -61,7 +61,7 @@ if ( ! class_exists( 'Timber_Acf_Wp_Blocks' ) ) {
 					$slug = $file_parts['filename'];
 
 					// Get header info from the found template file(s).
-					$file_path    = locate_template( $dir . "/${slug}.twig" );
+					$file_path    = locate_template( $dir . "/{$slug}.twig" );
 					$file_headers = get_file_data(
 						$file_path,
 						array(
@@ -132,7 +132,7 @@ if ( ! class_exists( 'Timber_Acf_Wp_Blocks' ) ) {
 					// If the SupportsAlignContent header is set in the template, restrict this block
 					// to those aligns.
 					if ( ! empty( $file_headers['supports_align_content'] ) ) {
-						$data['supports']['alignContent'] = ('true' === $file_headers['supports_align_content']) ? 
+						$data['supports']['alignContent'] = ('true' === $file_headers['supports_align_content']) ?
 							true : (('matrix' === $file_headers['supports_align_content']) ? "matrix" : false);
 					}
 					// If the SupportsMode header is set in the template, restrict this block


### PR DESCRIPTION
PHP 8.2 

Deprecated: Using ${var} in strings is deprecated, use {$var} instead in ***/vendor/palmiak/timber-acf-wp-blocks/timber-acf-wp-blocks.php on line 64