### PR TITLE
Deprecate "variable variable" string interpolation

### DIFF
--- a/timber-acf-wp-blocks.php
+++ b/timber-acf-wp-blocks.php
@@ -61,7 +61,7 @@ if ( ! class_exists( 'Timber_Acf_Wp_Blocks' ) ) {
 					$slug = $file_parts['filename'];
 
 					// Get header info from the found template file(s).
-					$file_path    = locate_template( $dir . "/${slug}.twig" );
+					$file_path    = locate_template( $dir . "/{$slug}.twig" );
 					$file_headers = get_file_data(
 						$file_path,
 						array(


### PR DESCRIPTION
PHP 8.2 and above deprecates this type of interpolation.

Read more here: https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation